### PR TITLE
Fixed Error Handler format + Unit Tests to ensure coverage

### DIFF
--- a/service/common/error_handlers.py
+++ b/service/common/error_handlers.py
@@ -37,9 +37,7 @@ def bad_request(error):
     message = str(error)
     app.logger.warning(message)
     return (
-        jsonify(
-            status=status.HTTP_400_BAD_REQUEST, error="Bad Request", message=message
-        ),
+        jsonify(error="Bad Request", message=message),
         status.HTTP_400_BAD_REQUEST,
     )
 
@@ -50,7 +48,7 @@ def not_found(error):
     message = str(error)
     app.logger.warning(message)
     return (
-        jsonify(status=status.HTTP_404_NOT_FOUND, error="Not Found", message=message),
+        jsonify(error="Not Found", message=message),
         status.HTTP_404_NOT_FOUND,
     )
 
@@ -61,11 +59,7 @@ def method_not_supported(error):
     message = str(error)
     app.logger.warning(message)
     return (
-        jsonify(
-            status=status.HTTP_405_METHOD_NOT_ALLOWED,
-            error="Method not Allowed",
-            message=message,
-        ),
+        jsonify(error="Method not Allowed", message=message),
         status.HTTP_405_METHOD_NOT_ALLOWED,
     )
 
@@ -76,11 +70,7 @@ def mediatype_not_supported(error):
     message = str(error)
     app.logger.warning(message)
     return (
-        jsonify(
-            status=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
-            error="Unsupported media type",
-            message=message,
-        ),
+        jsonify(error="Unsupported media type", message=message),
         status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
     )
 
@@ -91,11 +81,7 @@ def internal_server_error(error):
     message = str(error)
     app.logger.error(message)
     return (
-        jsonify(
-            status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            error="Internal Server Error",
-            message=message,
-        ),
+        jsonify(error="Internal Server Error", message=message),
         status.HTTP_500_INTERNAL_SERVER_ERROR,
     )
 


### PR DESCRIPTION
Remove old HTML error handlers
* Added RESTX JSON error handlers (@api.errorhandler) in routes.py (lines 52-82)
* All error handlers return JSON, not HTML
* Flask error handlers in error_handlers.py also return JSON using jsonify()

Fix pytest failures caused by RESTX
* All 81 tests pass
* Fixed error message capitalization ("Unsupported media type")
* Fixed index route URL building