### PR TITLE
Add Tekton pipeline and tasks for Req6

### DIFF
--- a/ .tekton/pipeline.yaml
+++ b/ .tekton/pipeline.yaml
@@ -1,0 +1,65 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: cd-pipeline
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/displayName: "CD Pipeline"
+spec:
+  workspaces:
+    - name: shared-workspace
+
+  tasks:
+    - name: clone
+      taskRef:
+        name: clone
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+
+    - name: lint
+      taskRef:
+        name: lint
+      runAfter:
+        - clone
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+
+    - name: test
+      taskRef:
+        name: test
+      runAfter:
+        - clone
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+
+    - name: build
+      taskRef:
+        name: build
+      runAfter:
+        - lint
+        - test
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+
+    - name: deploy
+      taskRef:
+        name: deploy
+      runAfter:
+        - build
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+
+    - name: bdd
+      taskRef:
+        name: bdd
+      runAfter:
+        - deploy
+      workspaces:
+        - name: source
+          workspace: shared-workspace

--- a/ .tekton/tasks.yaml
+++ b/ .tekton/tasks.yaml
@@ -1,0 +1,99 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: clone
+spec:
+  workspaces:
+    - name: source
+  params:
+    - name: url
+      type: string
+    - name: revision
+      type: string
+      default: "main"
+  steps:
+    - name: clone
+      image: alpine/git
+      script: |
+        #!/bin/sh
+        set -e
+        git clone $(params.url) --branch $(params.revision) /workspace/source
+
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: lint
+spec:
+  workspaces:
+    - name: source
+  steps:
+    - name: lint
+      image: python:3.11-slim
+      workingDir: $(workspaces.source.path)
+      script: |
+        pip install pylint flake8
+        flake8 .
+        pylint service || true
+
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: test
+spec:
+  workspaces:
+    - name: source
+  steps:
+    - name: test
+      image: python:3.11-slim
+      workingDir: $(workspaces.source.path)
+      script: |
+        pip install pytest
+        pytest
+
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: build
+spec:
+  workspaces:
+    - name: source
+  steps:
+    - name: build
+      image: alpine
+      script: |
+        #!/bin/sh
+        echo "Build step placeholder. No actual image build performed."
+
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: deploy
+spec:
+  workspaces:
+    - name: source
+  steps:
+    - name: deploy
+      image: alpine
+      script: |
+        #!/bin/sh
+        echo "Deploy step placeholder. No actual deployment performed."
+
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: bdd
+spec:
+  workspaces:
+    - name: source
+  steps:
+    - name: bdd
+      image: alpine
+      script: |
+        #!/bin/sh
+        echo "BDD tests placeholder."


### PR DESCRIPTION
This PR adds the initial Tekton CD pipeline for Requirement 6.

Included:
- .tekton/pipeline.yaml (pipeline definition)
- .tekton/tasks.yaml (clone, lint, test, build, deploy, bdd tasks)
- Basic placeholder build/deploy/bdd steps as required

The pipeline includes 6 tasks and follows the spec:
clone → (lint & test in parallel) → build → deploy → bdd

No cluster login info included, only pipeline manifests as required.